### PR TITLE
Fix for websocket client when used in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/GraftJS/graft",
   "dependencies": {
     "inherits": "^2.0.1",
-    "jschan": "^0.2.0",
+    "jschan": "^0.2.1",
     "readable-stream": "^1.0.31"
   },
   "devDependencies": {

--- a/ws.js
+++ b/ws.js
@@ -44,7 +44,7 @@ inherits(WSClient, Client);
 
 WSClient.prototype._buildSession = function(opts) {
   var client = jschan.websocketClientSession(opts);
-  client._inStream.socket.on('open', this.emit.bind(this, 'ready', this));
+  client._inStream.on('connect', this.emit.bind(this, 'ready', this));
   return client;
 };
 


### PR DESCRIPTION
- Bumped jschan version
- Fixed connection handler for websocket client

Conversation: https://github.com/GraftJS/graft/commit/eabd737c0c511e2e7d81ee8906213bda674ddc42
